### PR TITLE
UPSE-296: updates for Java 11 (JAXB issues); downgrade logback to Jav…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,13 +28,16 @@ on:
 
 jobs:
   test:
-    name: '${{ matrix.platform }} with Java 8'
+    name: '${{ matrix.platform }} with Java ${{ matrix.java-version}}'
     strategy:
       matrix:
         platform:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java-version:
+          - 8
+          - 11
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -43,6 +46,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: ${{ matrix.java-version }}
       - name: Build and Test
         run: mvn -B package

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,12 @@
   </issueManagement>
 
   <properties>
-    <logbackVersion>1.4.5</logbackVersion>
-    <slf4jVersion>1.7.36</slf4jVersion>
+    <logbackVersion>1.3.5</logbackVersion>
+    <slf4jVersion>2.0.6</slf4jVersion>
     <spring.version>4.3.30.RELEASE</spring.version>
     <uportal-libs.version>5.12.0</uportal-libs.version>
+    <jaxb-api.version>2.3.1</jaxb-api.version>
+    <jaxb-impl.version>2.3.3</jaxb-impl.version>
   </properties>
 
   <dependencies>
@@ -142,6 +144,18 @@
           <artifactId>validation-api</artifactId>
           <version>2.0.1.Final</version>
       </dependency>
+
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb-api.version}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${jaxb-impl.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
…a 8 compatible version

Updated to work with Tomcat running with Java 11 (added JAXB jars).
Still works with Tomcat running with Java 8.
Downgraded logback, to version that works with Java 8+ (1.3.x).  Versions 1.4.x do not work with Java 8 but there is no compile-time error so you don't find out until the portlet fails to start up.